### PR TITLE
Fix the docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer/composer
+FROM composer
 
 WORKDIR /app
 

--- a/start_zenaton
+++ b/start_zenaton
@@ -5,4 +5,5 @@ set -e
 zenaton start
 zenaton listen --boot=src/bootstrap.php
 
+touch zenaton.out
 tail -f zenaton.out


### PR DESCRIPTION
The `composer/composer` docker image is outdated and does not work anymore: composer downloads the packages, but the vendor directory is never created.

So we move to the new official docker image.