### PR TITLE
fix the docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
 FROM composer
 
+FROM php:7.2-cli-stretch
+
+RUN apt-get update && apt-get install git unzip -y
+
 WORKDIR /app
+
+EXPOSE 4001
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY ./bin /app/bin
+COPY ./src /app/src
+COPY ./start_zenaton /app/start_zenaton
+ADD composer.json composer.lock ./
+
+RUN composer install
 
 # Install Zenaton
 RUN curl https://install.zenaton.com | sh
-
-# Install dependencies
-ADD composer.json composer.lock ./
-RUN composer install
 
 ENTRYPOINT ["./start_zenaton"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY ./bin /app/bin
 COPY ./src /app/src
 COPY ./start_zenaton /app/start_zenaton
-ADD composer.json composer.lock ./
+COPY composer.json composer.lock ./
 
 RUN composer install
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ git clone https://github.com/zenaton/examples-php.git; cd examples-php
 
 Then, populate your `.env` file with your application id and api token found [here](https://app.zenaton.com/api).
 
+Then Install dependencies
+
+```sh
+composer install
+```
+
 ### Running on Docker
 
 Simply run
@@ -49,18 +55,12 @@ php bin/launch_sequential.php
 When using the docker setup, you can run PHP inside the container using the following command instead:
 
 ```sh
-docker-compose exec php bin/launch_sequential.php
+docker-compose exec app bin/launch_sequential.php
 ```
 
 ### Running locally
 
-Install dependencies
-
-```sh
-composer install
-```
-
-Then, you need to install a Zenaton worker
+Install a Zenaton worker
 
 ```sh
 curl https://install.zenaton.com | sh

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Clone this repository
 git clone https://github.com/zenaton/examples-php.git; cd examples-php
 ```
 
-Then, populate your `.env` file with your application id and api token found [here](https://app.zenaton.com/api).
-
 Then Install dependencies
 
 ```sh
 composer install
 ```
+
+Then, populate your `.env` file with your application id and api token found [here](https://app.zenaton.com/api).
 
 ### Running on Docker
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Simply run
 docker-compose build; docker-compose up
 ```
 
+You can check that your agent is running [here](https://app.zenaton.com/agents).
+
 You're all set!
 
 While going through the next sections, you will see you have to run examples using commands like the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - .:/app
     ports:
       - "4001:4001"
+    env_file:
+      - .env

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -8,7 +8,9 @@ if (!class_exists('Zenaton\Client')) {
 }
 
 // load .env file
-(new Dotenv\Dotenv(realpath(__DIR__.'/..')))->overload();
+if (file_exists(__DIR__.'/../.env')) {
+    (new Dotenv\Dotenv(realpath(__DIR__.'/..')))->overload();
+}
 
 $appId = getenv('ZENATON_APP_ID');
 if (!$appId) {


### PR DESCRIPTION
# CHANGES:

The `.env` file is now optional.

If it not exists, environment variables will be used.

This allows you to use `.env` in local to ease development. 

And for deploy, where you do not want to put credentials in the image, you can use environment variables.

This will ease a lot the deploy on Cloud environments.